### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,6 +1,9 @@
 
 name: Super-Linter
 
+permissions:
+  contents: read
+
 on: push
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/pshutt97/super-linter/security/code-scanning/1](https://github.com/pshutt97/super-linter/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the permissions for the `GITHUB_TOKEN`. Since this is a linting workflow, it only needs read access to the repository contents. We will set `permissions: contents: read` at the root level of the workflow to apply it to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
